### PR TITLE
 feat: Add service layer and refactor data model

### DIFF
--- a/src/main/java/io/everyonecodes/pbl_module_milihe/PblModuleMiliheApplication.java
+++ b/src/main/java/io/everyonecodes/pbl_module_milihe/PblModuleMiliheApplication.java
@@ -2,6 +2,8 @@ package io.everyonecodes.pbl_module_milihe;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean; // Import for @Bean annotation
+import org.springframework.web.client.RestTemplate; // Import for RestTemplate
 
 @SpringBootApplication
 public class PblModuleMiliheApplication {
@@ -10,4 +12,14 @@ public class PblModuleMiliheApplication {
 		SpringApplication.run(PblModuleMiliheApplication.class, args);
 	}
 
+	/**
+	 * Defines a RestTemplate bean.
+	 * RestTemplate is used for making synchronous HTTP requests to external APIs (like Spoonacular).
+	 * Spring will manage this bean and inject it wherever it's needed (e.g., in SpoonacularApiService).
+	 * @return A new instance of RestTemplate.
+	 */
+	@Bean
+	public RestTemplate restTemplate() {
+		return new RestTemplate();
+	}
 }

--- a/src/main/java/io/everyonecodes/pbl_module_milihe/dto/RecipeDTO.java
+++ b/src/main/java/io/everyonecodes/pbl_module_milihe/dto/RecipeDTO.java
@@ -4,6 +4,8 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
@@ -22,4 +24,6 @@ public class RecipeDTO {
     private String summary;
     private String stepByStepInstruction;
     private String image;
+    private String sourceUrl;
+    private List<RecipeIngredientDTO> extendedIngredients;
 }

--- a/src/main/java/io/everyonecodes/pbl_module_milihe/dto/RecipeIngredientDTO.java
+++ b/src/main/java/io/everyonecodes/pbl_module_milihe/dto/RecipeIngredientDTO.java
@@ -4,12 +4,17 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+/**
+ * DTO for transferring RecipeIngredient data, combining details
+ * from both RecipeIngredient and Ingredient entities for frontend display.
+ * The 'id' field has been removed as the JPA entity uses a composite key
+ * and does not expose a simple Long ID for this join entity.
+ */
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 public class RecipeIngredientDTO {
-
-    private Long id;
+    // private Long id;
     private int spoonacularId;
     private String name;
     private String originalString;

--- a/src/main/java/io/everyonecodes/pbl_module_milihe/jpa/Ingredient.java
+++ b/src/main/java/io/everyonecodes/pbl_module_milihe/jpa/Ingredient.java
@@ -1,39 +1,56 @@
 package io.everyonecodes.pbl_module_milihe.jpa;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
+/**
+ * JPA Entity for an Ingredient. Represents a single ingredient.
+ * It now includes a bidirectional @OneToMany relationship to RecipeIngredient.
+ */
 @Entity
 @Table(name = "ingredient")
-@Data
+@Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 public class Ingredient {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
     private int spoonacularId;
     private String name;
     private String image;
 
-    @OneToMany(mappedBy = "ingredientId", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "ingredient", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private List<RecipeIngredient> recipeIngredients = new ArrayList<>();
 
     public void addRecipeIngredient(RecipeIngredient recipeIngredient) {
         recipeIngredients.add(recipeIngredient);
-
-        recipeIngredient.setIngredientId(this.id);
-
+        recipeIngredient.setIngredient(this);
+        if (this.id != null && recipeIngredient.getRecipe() != null && recipeIngredient.getRecipe().getId() != null) {
+            recipeIngredient.setId(new RecipeIngredientId(recipeIngredient.getRecipe().getId(), this.id));
+        }
     }
 
     public void removeRecipeIngredient(RecipeIngredient recipeIngredient) {
         recipeIngredients.remove(recipeIngredient);
-        recipeIngredient.setIngredientId(null);
+        recipeIngredient.setIngredient(null);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Ingredient that = (Ingredient) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return getClass().hashCode();
     }
 }

--- a/src/main/java/io/everyonecodes/pbl_module_milihe/jpa/Recipe.java
+++ b/src/main/java/io/everyonecodes/pbl_module_milihe/jpa/Recipe.java
@@ -1,23 +1,26 @@
 package io.everyonecodes.pbl_module_milihe.jpa;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
+/**
+ * JPA Entity for a Recipe. Represents a single recipe with its details.
+ * It now includes a bidirectional @OneToMany relationship to RecipeIngredient.
+ */
 @Entity
 @Table(name = "recipe")
-@Data
+@Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 public class Recipe {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
     private int spoonacularId;
     private String title;
     private int readyInMinutes;
@@ -33,19 +36,34 @@ public class Recipe {
 
     @Column(columnDefinition = "TEXT")
     private String stepByStepInstruction;
+    private String image;
+    private String sourceUrl;
 
-    @OneToMany(mappedBy = "recipeId", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "recipe", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private List<RecipeIngredient> recipeIngredients = new ArrayList<>();
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Recipe recipe = (Recipe) o;
+        return id != null && Objects.equals(id, recipe.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return getClass().hashCode();
+    }
+
 
     public void addRecipeIngredient(RecipeIngredient recipeIngredient) {
         recipeIngredients.add(recipeIngredient);
-
-        recipeIngredient.setRecipeId(this.id);
-
+        recipeIngredient.setRecipe(this);
     }
 
     public void removeRecipeIngredient(RecipeIngredient recipeIngredient) {
         recipeIngredients.remove(recipeIngredient);
-        recipeIngredient.setRecipeId(null);
+        recipeIngredient.setRecipe(null);
     }
+
 }

--- a/src/main/java/io/everyonecodes/pbl_module_milihe/jpa/RecipeIngredient.java
+++ b/src/main/java/io/everyonecodes/pbl_module_milihe/jpa/RecipeIngredient.java
@@ -1,32 +1,56 @@
 package io.everyonecodes.pbl_module_milihe.jpa;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
 import jakarta.persistence.*;
+import lombok.*;
 
+import java.util.Objects;
+
+/**
+ * JPA Entity for RecipeIngredient.
+ * Represents the many-to-many relationship between Recipe and Ingredient,
+ * with additional attributes like amount and unit.
+ * It uses a composite primary key defined by RecipeIngredientId.
+ */
 @Entity
 @Table(name = "recipe_ingredient")
-@Data
+@Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 public class RecipeIngredient {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-
-    @Column(name = "recipe_id", nullable = false)
-    private Long recipeId;
-
-    @Column(name = "ingredient_id", nullable = false)
-    private Long ingredientId;
-
+    @EmbeddedId
+    private RecipeIngredientId id;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId("recipeId")
+    @JoinColumn(name = "recipe_id")
+    private Recipe recipe;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId("ingredientId")
+    @JoinColumn(name = "ingredient_id")
+    private Ingredient ingredient;
     private double amount;
-
     private String unit;
-
-    @Column(name = "original_string", columnDefinition = "TEXT")
     private String originalString;
+
+    public RecipeIngredient(Recipe recipe, Ingredient ingredient, double amount, String unit, String originalString) {
+        this.recipe = recipe;
+        this.ingredient = ingredient;
+        this.amount = amount;
+        this.unit = unit;
+        this.originalString = originalString;
+        this.id = new RecipeIngredientId(recipe.getId(), ingredient.getId());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        RecipeIngredient that = (RecipeIngredient) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return getClass().hashCode();
+    }
 }

--- a/src/main/java/io/everyonecodes/pbl_module_milihe/jpa/RecipeIngredientId.java
+++ b/src/main/java/io/everyonecodes/pbl_module_milihe/jpa/RecipeIngredientId.java
@@ -1,0 +1,16 @@
+package io.everyonecodes.pbl_module_milihe.jpa;
+
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.io.Serializable;
+
+@Embeddable
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class RecipeIngredientId implements Serializable {
+    private Long recipeId;
+    private Long ingredientId;
+}

--- a/src/main/java/io/everyonecodes/pbl_module_milihe/repository/RecipeIngredientRepository.java
+++ b/src/main/java/io/everyonecodes/pbl_module_milihe/repository/RecipeIngredientRepository.java
@@ -1,7 +1,13 @@
 package io.everyonecodes.pbl_module_milihe.repository;
 
 import io.everyonecodes.pbl_module_milihe.jpa.RecipeIngredient;
+import io.everyonecodes.pbl_module_milihe.jpa.RecipeIngredientId;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
-public interface RecipeIngredientRepository extends JpaRepository<RecipeIngredient, Long> {
+import java.util.List;
+
+@Repository
+public interface RecipeIngredientRepository extends JpaRepository<RecipeIngredient, RecipeIngredientId> {
+    List<RecipeIngredient> findByRecipe_Id(Long recipeId);
 }

--- a/src/main/java/io/everyonecodes/pbl_module_milihe/repository/RecipeRepository.java
+++ b/src/main/java/io/everyonecodes/pbl_module_milihe/repository/RecipeRepository.java
@@ -2,6 +2,13 @@ package io.everyonecodes.pbl_module_milihe.repository;
 
 import io.everyonecodes.pbl_module_milihe.jpa.Recipe;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
 
-    public interface RecipeRepository extends JpaRepository<Recipe, Long> {
-    }
+import java.util.List;
+
+@Repository
+public interface RecipeRepository extends JpaRepository<Recipe, Long> {
+    @Query("SELECT r FROM Recipe r LEFT JOIN FETCH r.recipeIngredients ri LEFT JOIN FETCH ri.ingredient")
+    List<Recipe> findAllWithIngredients();
+}

--- a/src/main/java/io/everyonecodes/pbl_module_milihe/service/IngredientService.java
+++ b/src/main/java/io/everyonecodes/pbl_module_milihe/service/IngredientService.java
@@ -1,0 +1,95 @@
+package io.everyonecodes.pbl_module_milihe.service;
+
+import io.everyonecodes.pbl_module_milihe.dto.IngredientDTO;
+import io.everyonecodes.pbl_module_milihe.jpa.Ingredient;
+import io.everyonecodes.pbl_module_milihe.repository.IngredientRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Service class for managing Ingredient entities and their associated DTOs.
+ * This class encapsulates the business logic related to ingredients,
+ * orchestrates interactions with the IngredientRepository, and handles the conversion
+ * between Ingredient JPA entities and IngredientDTOs.
+ */
+@Service
+public class IngredientService {
+
+    private final IngredientRepository ingredientRepository;
+
+    /**
+     * Constructor for IngredientService.
+     * Spring automatically injects the required repository instance.
+     * @param ingredientRepository The repository for Ingredient entities.
+     */
+    public IngredientService(IngredientRepository ingredientRepository) {
+        this.ingredientRepository = ingredientRepository;
+    }
+
+    /**
+     * Saves a new Ingredient entity to the database.
+     * @param ingredient The Ingredient entity to save.
+     * @return The saved Ingredient entity, potentially with an updated ID.
+     */
+    public Ingredient saveIngredient(Ingredient ingredient) {
+        return ingredientRepository.save(ingredient);
+    }
+
+    /**
+     * Retrieves all Ingredient entities from the database and converts them into IngredientDTOs.
+     * @return A list of IngredientDTOs.
+     */
+    public List<IngredientDTO> findAllIngredients() {
+        List<Ingredient> ingredients = ingredientRepository.findAll();
+        return ingredients.stream()
+                .map(this::toIngredientDTO)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Retrieves a single Ingredient entity by its ID and converts it into an IngredientDTO.
+     * @param id The ID of the ingredient to retrieve.
+     * @return An Optional containing the IngredientDTO if found, or an empty Optional if not.
+     */
+    public Optional<IngredientDTO> findIngredientById(Long id) {
+        Optional<Ingredient> ingredientOptional = ingredientRepository.findById(id);
+        return ingredientOptional.map(this::toIngredientDTO);
+    }
+
+    /**
+     * Converts an Ingredient JPA entity into an IngredientDTO.
+     * This method is responsible for mapping fields from the entity to the DTO.
+     * @param ingredient The Ingredient JPA entity to convert.
+     * @return The corresponding IngredientDTO.
+     */
+    private IngredientDTO toIngredientDTO(Ingredient ingredient) {
+        return new IngredientDTO(
+                ingredient.getId(),
+                ingredient.getSpoonacularId(),
+                ingredient.getName(),
+                ingredient.getImage()
+        );
+    }
+
+    /**
+     * Converts an IngredientDTO to an Ingredient JPA entity.
+     * Note: ID might be null for new entities.
+     * This method now correctly matches the constructor of the Ingredient JPA entity
+     * by providing an empty ArrayList for the 'recipeIngredients' list.
+     * @param dto The IngredientDTO.
+     * @return The corresponding Ingredient entity.
+     */
+    public Ingredient fromIngredientDTO(IngredientDTO dto) {
+        return new Ingredient(
+                dto.getId(),
+                dto.getSpoonacularId(),
+                dto.getName(),
+                dto.getImage(),
+                new ArrayList<>()
+        );
+    }
+}

--- a/src/main/java/io/everyonecodes/pbl_module_milihe/service/RecipeService.java
+++ b/src/main/java/io/everyonecodes/pbl_module_milihe/service/RecipeService.java
@@ -1,0 +1,135 @@
+package io.everyonecodes.pbl_module_milihe.service;
+
+import io.everyonecodes.pbl_module_milihe.dto.RecipeDTO;
+import io.everyonecodes.pbl_module_milihe.dto.RecipeIngredientDTO;
+import io.everyonecodes.pbl_module_milihe.jpa.Ingredient;
+import io.everyonecodes.pbl_module_milihe.jpa.Recipe;
+import io.everyonecodes.pbl_module_milihe.jpa.RecipeIngredient;
+import io.everyonecodes.pbl_module_milihe.repository.IngredientRepository;
+import io.everyonecodes.pbl_module_milihe.repository.RecipeIngredientRepository;
+import io.everyonecodes.pbl_module_milihe.repository.RecipeRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Service class for managing Recipe entities and their associated DTOs.
+ * This class encapsulates the business logic related to recipes,
+ * orchestrates interactions with repositories, and handles the conversion
+ * between JPA entities and DTOs for external consumption.
+ */
+@Service
+public class RecipeService {
+    private final RecipeRepository recipeRepository;
+    private final IngredientRepository ingredientRepository;
+    private final RecipeIngredientRepository recipeIngredientRepository;
+
+    /**
+     * Constructor for RecipeService.
+     * Spring automatically injects the required repository instances.
+     *
+     * @param recipeRepository           The repository for Recipe entities.
+     * @param ingredientRepository       The repository for Ingredient entities.
+     * @param recipeIngredientRepository The repository for RecipeIngredient entities.
+     */
+    public RecipeService(RecipeRepository recipeRepository,
+                         IngredientRepository ingredientRepository,
+                         RecipeIngredientRepository recipeIngredientRepository) {
+        this.recipeRepository = recipeRepository;
+        this.ingredientRepository = ingredientRepository;
+        this.recipeIngredientRepository = recipeIngredientRepository;
+    }
+
+    /**
+     * Saves a new Recipe entity to the database.
+     * This method directly saves the JPA entity. In more complex scenarios,
+     * you might take a RecipeDTO and convert it to a Recipe entity here.
+     *
+     * @param recipe The Recipe entity to save.
+     * @return The saved Recipe entity, potentially with an updated ID.
+     */
+    public Recipe saveRecipe(Recipe recipe) {
+        return recipeRepository.save(recipe);
+    }
+
+    /**
+     * Retrieves all Recipe entities from the database and converts them into RecipeDTOs.
+     * This method demonstrates fetching entities and then transforming them for the client.
+     *
+     * @return A list of RecipeDTOs.
+     */
+    public List<RecipeDTO> findAllRecipes() {
+        List<Recipe> recipes = recipeRepository.findAllWithIngredients();
+
+        return recipes.stream()
+                .map(this::toRecipeDTO)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Retrieves a single Recipe entity by its ID and converts it into a RecipeDTO.
+     *
+     * @param id The ID of the recipe to retrieve.
+     * @return An Optional containing the RecipeDTO if found, or an empty Optional if not.
+     */
+    public Optional<RecipeDTO> findRecipeById(Long id) {
+        Optional<Recipe> recipeOptional = recipeRepository.findById(id);
+        return recipeOptional.map(this::toRecipeDTO);
+    }
+
+    /**
+     * Converts a Recipe JPA entity into a RecipeDTO.
+     * This method is responsible for mapping fields and, importantly,
+     * building the list of RecipeIngredientDTOs by fetching associated ingredient details.
+     *
+     * @param recipe The Recipe JPA entity to convert.
+     * @return The corresponding RecipeDTO.
+     */
+    private RecipeDTO toRecipeDTO(Recipe recipe) {
+
+        List<RecipeIngredientDTO> recipeIngredientDTOs = recipe.getRecipeIngredients().stream()
+                .map(this::toRecipeIngredientDTO)
+                .collect(Collectors.toList());
+
+        return new RecipeDTO(
+                recipe.getId(),
+                recipe.getSpoonacularId(),
+                recipe.getTitle(),
+                recipe.getReadyInMinutes(),
+                recipe.getServings(),
+                recipe.isVegetarian(),
+                recipe.isVegan(),
+                recipe.isGlutenFree(),
+                recipe.isDairyFree(),
+                recipe.getHealthScore(),
+                recipe.getSummary(),
+                recipe.getStepByStepInstruction(),
+                recipe.getImage(),
+                recipe.getSourceUrl(),
+                recipeIngredientDTOs
+        );
+    }
+
+    /**
+     * Converts a RecipeIngredient JPA entity into a RecipeIngredientDTO.
+     * This method fetches the corresponding Ingredient details to enrich the DTO.
+     * This directly addresses Task 3's requirement to combine data.
+     *
+     * @param recipeIngredient The RecipeIngredient JPA entity to convert.
+     * @return The corresponding RecipeIngredientDTO.
+     */
+    private RecipeIngredientDTO toRecipeIngredientDTO(RecipeIngredient recipeIngredient) {
+
+        Ingredient ingredient = recipeIngredient.getIngredient();
+        return new RecipeIngredientDTO(
+                ingredient != null ? ingredient.getSpoonacularId() : 0,
+                ingredient != null ? ingredient.getName() : "Unknown Ingredient",
+                recipeIngredient.getOriginalString(),
+                recipeIngredient.getAmount(),
+                recipeIngredient.getUnit(),
+                ingredient != null ? ingredient.getImage() : null
+        );
+    }
+}

--- a/src/main/java/io/everyonecodes/pbl_module_milihe/service/SpoonacularApiService.java
+++ b/src/main/java/io/everyonecodes/pbl_module_milihe/service/SpoonacularApiService.java
@@ -1,0 +1,54 @@
+package io.everyonecodes.pbl_module_milihe.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.beans.factory.annotation.Value;
+
+/**
+ * Service for interacting with the Spoonacular external API.
+ * This class will handle making HTTP requests to Spoonacular endpoints
+ * and mapping their responses to internal DTOs or JPA entities.
+ */
+@Service
+public class SpoonacularApiService {
+
+    @Value("${spoonacular.api.key}")
+    private String apiKey;
+
+    private final String BASE_URL = "https://api.spoonacular.com";
+
+
+    private final RestTemplate restTemplate;
+
+    /**
+     * Constructor for SpoonacularApiService.
+     * Spring automatically injects RestTemplate.
+     * @param restTemplate The RestTemplate instance for making HTTP calls.
+     */
+    public SpoonacularApiService(RestTemplate restTemplate) {
+        this.restTemplate = restTemplate;
+    }
+
+    /**
+     * Placeholder method to search for recipes from Spoonacular.
+     * This method would typically make a GET request to /recipes/complexSearch.
+     * @param query The search query (e.g., "pasta with chicken")
+     * @return A placeholder String (will be SpoonacularRecipeSearchResponse DTO later)
+     */
+    public String searchRecipes(String query) {
+        System.out.println("SpoonacularApiService: Searching recipes for query: " + query);
+        return "Placeholder for Spoonacular recipe search results.";
+    }
+
+    /**
+     * Placeholder method to get full recipe details by Spoonacular ID.
+     * This method would typically make a GET request to /recipes/{id}/information.
+     * @param spoonacularId The ID of the recipe from Spoonacular.
+     * @return A placeholder String (will be SpoonacularRecipeDetailsResponse DTO later)
+     */
+    public String getRecipeDetails(int spoonacularId) {
+        System.out.println("SpoonacularApiService: Getting details for Spoonacular ID: " + spoonacularId);
+        return "Placeholder for Spoonacular recipe details.";
+    }
+
+}


### PR DESCRIPTION
    This commit introduces the core service layer for the application and includes critical refactoring and fixes for the data model.

    - Adds `RecipeService`, `IngredientService`, and a placeholder for `SpoonacularApiService` to encapsulate business logic.

    - Fixes a critical bug in `RecipeIngredientRepository` by correcting the generic ID type to use the composite key (`RecipeIngredientId`).

    - Implements a major performance optimization by using `JOIN FETCH` in `RecipeRepository` to solve the N+1 query problem when finding all recipes.

    -Refactors JPA entity classes (`Recipe`, `Ingredient`, `RecipeIngredient`) to replace Lombok's `@Data` with safer, more explicit annotations (`@Getter`, `@Setter`)
    and proper `equals()`/`hashCode()` implementations to prevent potential `StackOverflowError` exceptions.