### PR TITLE
feat: Implement Spoonacular API client and data sync service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ target/
 .springBeans
 .sts4-cache
 application.properties
+src/test/resources/application.properties
 
 ### IntelliJ IDEA ###
 .idea

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,11 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/io/everyonecodes/pbl_module_milihe/PblModuleMiliheApplication.java
+++ b/src/main/java/io/everyonecodes/pbl_module_milihe/PblModuleMiliheApplication.java
@@ -2,8 +2,7 @@ package io.everyonecodes.pbl_module_milihe;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.Bean; // Import for @Bean annotation
-import org.springframework.web.client.RestTemplate; // Import for RestTemplate
+
 
 @SpringBootApplication
 public class PblModuleMiliheApplication {
@@ -12,14 +11,4 @@ public class PblModuleMiliheApplication {
 		SpringApplication.run(PblModuleMiliheApplication.class, args);
 	}
 
-	/**
-	 * Defines a RestTemplate bean.
-	 * RestTemplate is used for making synchronous HTTP requests to external APIs (like Spoonacular).
-	 * Spring will manage this bean and inject it wherever it's needed (e.g., in SpoonacularApiService).
-	 * @return A new instance of RestTemplate.
-	 */
-	@Bean
-	public RestTemplate restTemplate() {
-		return new RestTemplate();
-	}
 }

--- a/src/main/java/io/everyonecodes/pbl_module_milihe/configuration/AppConfig.java
+++ b/src/main/java/io/everyonecodes/pbl_module_milihe/configuration/AppConfig.java
@@ -1,0 +1,14 @@
+package io.everyonecodes.pbl_module_milihe.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class AppConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/io/everyonecodes/pbl_module_milihe/controller/DataSetupController.java
+++ b/src/main/java/io/everyonecodes/pbl_module_milihe/controller/DataSetupController.java
@@ -1,65 +1,82 @@
 package io.everyonecodes.pbl_module_milihe.controller;
 
+import io.everyonecodes.pbl_module_milihe.dto.spoonacular.SpoonacularSearchResponse;
 import io.everyonecodes.pbl_module_milihe.jpa.Ingredient;
 import io.everyonecodes.pbl_module_milihe.jpa.Recipe;
 import io.everyonecodes.pbl_module_milihe.jpa.RecipeIngredient;
 import io.everyonecodes.pbl_module_milihe.repository.IngredientRepository;
+import io.everyonecodes.pbl_module_milihe.repository.RecipeIngredientRepository;
 import io.everyonecodes.pbl_module_milihe.repository.RecipeRepository;
+import io.everyonecodes.pbl_module_milihe.service.SpoonacularApiService;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
+/**
+ * A controller with special endpoints for development and testing purposes.
+ * This should be disabled or removed in a production environment.
+ */
 @RestController
 @RequestMapping("/api/setup")
 public class DataSetupController {
 
     private final RecipeRepository recipeRepository;
     private final IngredientRepository ingredientRepository;
+    private final RecipeIngredientRepository recipeIngredientRepository;
+    private final SpoonacularApiService spoonacularApiService;
 
-    public DataSetupController(RecipeRepository recipeRepository, IngredientRepository ingredientRepository) {
+    public DataSetupController(RecipeRepository recipeRepository,
+                               IngredientRepository ingredientRepository,
+                               RecipeIngredientRepository recipeIngredientRepository,
+                               SpoonacularApiService spoonacularApiService) {
         this.recipeRepository = recipeRepository;
         this.ingredientRepository = ingredientRepository;
+        this.recipeIngredientRepository = recipeIngredientRepository;
+        this.spoonacularApiService = spoonacularApiService;
     }
 
+    /**
+     * Endpoint to create a static, predefined set of test data in the database.
+     * This is useful for predictable manual and automated testing.
+     * NOTE: This is a POST request because it modifies data.
+     */
     @PostMapping("/data")
     @Transactional
     public String setupData() {
+        recipeIngredientRepository.deleteAll();
+        recipeRepository.deleteAll();
+        ingredientRepository.deleteAll();
+
         Ingredient tomato = ingredientRepository.save(new Ingredient("Tomato", "tomato.jpg"));
         Ingredient pasta = ingredientRepository.save(new Ingredient("Pasta", "pasta.jpg"));
         Ingredient lentil = ingredientRepository.save(new Ingredient("Lentils", "lentils.jpg"));
         Ingredient onion = ingredientRepository.save(new Ingredient("Onion", "onion.jpg"));
 
-        Recipe pastaRecipe = new Recipe();
-        pastaRecipe.setTitle("Classic Pasta");
-        pastaRecipe.setSummary("A simple pasta dish.");
-        pastaRecipe.setVegan(false);
-        pastaRecipe.setVegetarian(true);
-        pastaRecipe.setDairyFree(false);
-        pastaRecipe.setGlutenFree(false);
-        pastaRecipe.setReadyInMinutes(20);
-        pastaRecipe.setServings(2);
-        pastaRecipe.setHealthScore(75);
+        Recipe pastaRecipe = recipeRepository.save(new Recipe("Classic Pasta", false));
+        Recipe lentilSoup = recipeRepository.save(new Recipe("Lentil Soup", true));
 
-        pastaRecipe.getIngredients().add(new RecipeIngredient(200, "g", pasta, pastaRecipe));
-        pastaRecipe.getIngredients().add(new RecipeIngredient(400, "g", tomato, pastaRecipe));
+        RecipeIngredient pastaLink = new RecipeIngredient(200, "g", pasta, pastaRecipe);
+        RecipeIngredient tomatoLink = new RecipeIngredient(400, "g", tomato, pastaRecipe);
+        RecipeIngredient lentilLink = new RecipeIngredient(150, "g", lentil, lentilSoup);
+        RecipeIngredient onionLink = new RecipeIngredient(1, "piece", onion, lentilSoup);
 
-        Recipe lentilSoup = new Recipe();
-        lentilSoup.setTitle("Lentil Soup");
-        lentilSoup.setSummary("A hearty vegan soup.");
-        lentilSoup.setVegan(true);
-        lentilSoup.setVegetarian(true);
-        lentilSoup.setDairyFree(true);
-        lentilSoup.setGlutenFree(true);
-        lentilSoup.setReadyInMinutes(45);
-        lentilSoup.setServings(4);
-        lentilSoup.setHealthScore(90);
-
-        lentilSoup.getIngredients().add(new RecipeIngredient(150, "g", lentil, lentilSoup));
-        lentilSoup.getIngredients().add(new RecipeIngredient(1, "piece", onion, lentilSoup));
-
-        recipeRepository.saveAll(List.of(pastaRecipe, lentilSoup));
+        recipeIngredientRepository.saveAll(List.of(pastaLink, tomatoLink, lentilLink, onionLink));
 
         return "Test data has been created successfully!";
+    }
+
+    /**
+     * A temporary endpoint to test the Spoonacular API client.
+     * When visited, it calls the service and returns the resulting DTO.
+     * @return The SpoonacularSearchResponse DTO, which gets converted to JSON.
+     */
+    @GetMapping("/test-spoonacular")
+    public SpoonacularSearchResponse testSpoonacular() {
+        System.out.println("--- TRIGGERING SPOONACULAR API TEST ---");
+        return spoonacularApiService.searchRecipes("pizza");
     }
 }

--- a/src/main/java/io/everyonecodes/pbl_module_milihe/controller/DataSyncController.java
+++ b/src/main/java/io/everyonecodes/pbl_module_milihe/controller/DataSyncController.java
@@ -1,0 +1,27 @@
+package io.everyonecodes.pbl_module_milihe.controller;
+
+import io.everyonecodes.pbl_module_milihe.service.DataSyncService;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/sync")
+public class DataSyncController {
+
+    private final DataSyncService dataSyncService;
+
+    public DataSyncController(DataSyncService dataSyncService) {
+        this.dataSyncService = dataSyncService;
+    }
+
+    /**
+     * A manual trigger endpoint to start the data synchronization process.
+     * @return A success message.
+     */
+    @PostMapping("/recipes")
+    public String triggerSync() {
+        dataSyncService.syncRecipes();
+        return "Spoonacular data sync initiated successfully!";
+    }
+}

--- a/src/main/java/io/everyonecodes/pbl_module_milihe/controller/RecipeController.java
+++ b/src/main/java/io/everyonecodes/pbl_module_milihe/controller/RecipeController.java
@@ -5,7 +5,6 @@ import io.everyonecodes.pbl_module_milihe.dto.RecipeSuggestionDTO;
 import io.everyonecodes.pbl_module_milihe.service.RecipeService;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -36,8 +35,6 @@ public class RecipeController {
                 .filter(RecipeDTO::isVegan)
                 .collect(Collectors.toList());
     }
-
-    // ... inside your RecipeController.java ...
 
     /**
      * Endpoint to find recipes based on a list of provided ingredients.

--- a/src/main/java/io/everyonecodes/pbl_module_milihe/dto/RecipeIngredientDTO.java
+++ b/src/main/java/io/everyonecodes/pbl_module_milihe/dto/RecipeIngredientDTO.java
@@ -12,13 +12,11 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 public class RecipeIngredientDTO {
-    // private Long id;
     private int spoonacularId;
     private String name;
     private String originalString;
     private double amount;
     private String unit;
     private String image;
-
 
 }

--- a/src/main/java/io/everyonecodes/pbl_module_milihe/dto/spoonacular/SpoonacularRecipeResult.java
+++ b/src/main/java/io/everyonecodes/pbl_module_milihe/dto/spoonacular/SpoonacularRecipeResult.java
@@ -1,0 +1,14 @@
+package io.everyonecodes.pbl_module_milihe.dto.spoonacular;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SpoonacularRecipeResult {
+    private int id; // spoonacularId
+    private String title;
+    private String image;
+}

--- a/src/main/java/io/everyonecodes/pbl_module_milihe/dto/spoonacular/SpoonacularSearchResponse.java
+++ b/src/main/java/io/everyonecodes/pbl_module_milihe/dto/spoonacular/SpoonacularSearchResponse.java
@@ -1,0 +1,14 @@
+package io.everyonecodes.pbl_module_milihe.dto.spoonacular;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SpoonacularSearchResponse {
+    private List<SpoonacularRecipeResult> results;
+    private int totalResults;
+}

--- a/src/main/java/io/everyonecodes/pbl_module_milihe/repository/RecipeIngredientRepository.java
+++ b/src/main/java/io/everyonecodes/pbl_module_milihe/repository/RecipeIngredientRepository.java
@@ -3,7 +3,6 @@ package io.everyonecodes.pbl_module_milihe.repository;
 import io.everyonecodes.pbl_module_milihe.jpa.RecipeIngredient;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
-
 import java.util.List;
 
 @Repository

--- a/src/main/java/io/everyonecodes/pbl_module_milihe/repository/RecipeRepository.java
+++ b/src/main/java/io/everyonecodes/pbl_module_milihe/repository/RecipeRepository.java
@@ -3,11 +3,26 @@ package io.everyonecodes.pbl_module_milihe.repository;
 import io.everyonecodes.pbl_module_milihe.jpa.Recipe;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 
 public interface RecipeRepository extends JpaRepository<Recipe, Long> {
     @Query("SELECT r FROM Recipe r LEFT JOIN FETCH r.ingredients ri LEFT JOIN FETCH ri.ingredient")
     List<Recipe> findAllWithIngredients();
+
+
+    @Query("SELECT r FROM Recipe r LEFT JOIN FETCH r.ingredients ri LEFT JOIN FETCH ri.ingredient WHERE r.id = :id")
+    Optional<Recipe> findByIdWithIngredients(@Param("id") Long id);
+
+    /**
+     * Checks if a Recipe with the given spoonacularId already exists in the database.
+     * This is a very efficient way to check for duplicates as it only returns true/false.
+     *
+     * @param spoonacularId The ID from the Spoonacular API.
+     * @return true if a recipe exists, false otherwise.
+     */
+    boolean existsBySpoonacularId(int spoonacularId);
 }

--- a/src/main/java/io/everyonecodes/pbl_module_milihe/service/DataSyncService.java
+++ b/src/main/java/io/everyonecodes/pbl_module_milihe/service/DataSyncService.java
@@ -1,0 +1,77 @@
+package io.everyonecodes.pbl_module_milihe.service;
+
+import io.everyonecodes.pbl_module_milihe.dto.spoonacular.SpoonacularRecipeResult;
+import io.everyonecodes.pbl_module_milihe.dto.spoonacular.SpoonacularSearchResponse;
+import io.everyonecodes.pbl_module_milihe.jpa.Recipe;
+import io.everyonecodes.pbl_module_milihe.repository.RecipeRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class DataSyncService {
+
+    private final SpoonacularApiService spoonacularApiService;
+    private final RecipeRepository recipeRepository;
+
+    public DataSyncService(SpoonacularApiService spoonacularApiService, RecipeRepository recipeRepository) {
+        this.spoonacularApiService = spoonacularApiService;
+        this.recipeRepository = recipeRepository;
+    }
+
+    /**
+     * Fetches a batch of recipes from Spoonacular and saves them to the local database.
+     * This method includes logic to prevent creating duplicate recipes by checking
+     * the spoonacularId before saving.
+     */
+    @Transactional
+    public void syncRecipes() {
+        System.out.println("--- Starting Spoonacular Data Sync ---");
+
+        SpoonacularSearchResponse response = spoonacularApiService.searchRecipes("italian");
+
+        if (response == null || response.getResults() == null) {
+            System.out.println("Failed to fetch recipes from Spoonacular. Aborting sync.");
+            return;
+        }
+
+        for (SpoonacularRecipeResult spoonacularRecipe : response.getResults()) {
+
+            boolean recipeExists = recipeRepository.existsBySpoonacularId(spoonacularRecipe.getId());
+
+            if (recipeExists) {
+                System.out.println("Recipe '" + spoonacularRecipe.getTitle() + "' (ID: " + spoonacularRecipe.getId() + ") already exists. Skipping.");
+                continue;
+            }
+
+            Recipe recipeEntity = convertToRecipeEntity(spoonacularRecipe);
+
+            recipeRepository.save(recipeEntity);
+            System.out.println("Saved new recipe: " + recipeEntity.getTitle());
+        }
+
+        System.out.println("--- Data Sync Finished ---");
+    }
+
+    /**
+     * A private helper method to map a SpoonacularRecipeResult DTO to our own Recipe JPA entity.
+     * @param dto The DTO from Spoonacular.
+     * @return Our corresponding Recipe entity.
+     */
+    private Recipe convertToRecipeEntity(SpoonacularRecipeResult dto) {
+        Recipe recipe = new Recipe();
+
+        recipe.setSpoonacularId(dto.getId());
+        recipe.setTitle(dto.getTitle());
+        recipe.setImage(dto.getImage());
+
+        recipe.setReadyInMinutes(0);
+        recipe.setServings(0);
+        recipe.setVegetarian(false);
+        recipe.setVegan(false);
+        recipe.setGlutenFree(false);
+        recipe.setDairyFree(false);
+        recipe.setHealthScore(0);
+
+        return recipe;
+    }
+}

--- a/src/main/java/io/everyonecodes/pbl_module_milihe/service/RecipeService.java
+++ b/src/main/java/io/everyonecodes/pbl_module_milihe/service/RecipeService.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.Comparator;
 
 /**
  * Service class for managing Recipe entities and their associated DTOs.
@@ -137,7 +138,7 @@ public class RecipeService {
             suggestions.add(suggestion);
         }
 
-        suggestions.sort((s1, s2) -> Integer.compare(s1.getMissingIngredientCount(), s2.getMissingIngredientCount()));
+        suggestions.sort(Comparator.comparingInt(RecipeSuggestionDTO::getMissingIngredientCount));
 
         return suggestions;
     }

--- a/src/main/java/io/everyonecodes/pbl_module_milihe/service/SpoonacularApiService.java
+++ b/src/main/java/io/everyonecodes/pbl_module_milihe/service/SpoonacularApiService.java
@@ -1,54 +1,41 @@
 package io.everyonecodes.pbl_module_milihe.service;
 
+import io.everyonecodes.pbl_module_milihe.dto.spoonacular.SpoonacularSearchResponse;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.util.UriComponentsBuilder;
 
-/**
- * Service for interacting with the Spoonacular external API.
- * This class will handle making HTTP requests to Spoonacular endpoints
- * and mapping their responses to internal DTOs or JPA entities.
- */
 @Service
 public class SpoonacularApiService {
+
+    private final RestTemplate restTemplate;
 
     @Value("${spoonacular.api.key}")
     private String apiKey;
 
     private final String BASE_URL = "https://api.spoonacular.com";
 
-
-    private final RestTemplate restTemplate;
-
-    /**
-     * Constructor for SpoonacularApiService.
-     * Spring automatically injects RestTemplate.
-     * @param restTemplate The RestTemplate instance for making HTTP calls.
-     */
     public SpoonacularApiService(RestTemplate restTemplate) {
         this.restTemplate = restTemplate;
     }
 
-    /**
-     * Placeholder method to search for recipes from Spoonacular.
-     * This method would typically make a GET request to /recipes/complexSearch.
-     * @param query The search query (e.g., "pasta with chicken")
-     * @return A placeholder String (will be SpoonacularRecipeSearchResponse DTO later)
-     */
-    public String searchRecipes(String query) {
-        System.out.println("SpoonacularApiService: Searching recipes for query: " + query);
-        return "Placeholder for Spoonacular recipe search results.";
-    }
+    public SpoonacularSearchResponse searchRecipes(String query) {
+        String url = UriComponentsBuilder.fromHttpUrl(BASE_URL)
+                .path("/recipes/complexSearch")
+                .queryParam("apiKey", apiKey)
+                .queryParam("query", query)
+                .queryParam("number", 10)
+                .toUriString();
 
-    /**
-     * Placeholder method to get full recipe details by Spoonacular ID.
-     * This method would typically make a GET request to /recipes/{id}/information.
-     * @param spoonacularId The ID of the recipe from Spoonacular.
-     * @return A placeholder String (will be SpoonacularRecipeDetailsResponse DTO later)
-     */
-    public String getRecipeDetails(int spoonacularId) {
-        System.out.println("SpoonacularApiService: Getting details for Spoonacular ID: " + spoonacularId);
-        return "Placeholder for Spoonacular recipe details.";
-    }
+        System.out.println("Calling Spoonacular API with URL: " + url);
 
+        try {
+            return restTemplate.getForObject(url, SpoonacularSearchResponse.class);
+        } catch (Exception e) {
+            System.err.println("Error calling Spoonacular API: " + e.getMessage());
+            e.printStackTrace();
+            return null;
+        }
+    }
 }

--- a/src/test/java/io/everyonecodes/pbl_module_milihe/service/DataSyncServiceTest.java
+++ b/src/test/java/io/everyonecodes/pbl_module_milihe/service/DataSyncServiceTest.java
@@ -1,0 +1,70 @@
+package io.everyonecodes.pbl_module_milihe.service;
+
+import io.everyonecodes.pbl_module_milihe.dto.spoonacular.SpoonacularRecipeResult;
+import io.everyonecodes.pbl_module_milihe.dto.spoonacular.SpoonacularSearchResponse;
+import io.everyonecodes.pbl_module_milihe.jpa.Recipe;
+import io.everyonecodes.pbl_module_milihe.repository.RecipeRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit test for the DataSyncService.
+ * This test verifies the business logic in isolation by using mocks
+ * for all external dependencies (API service and repository).
+ */
+public class DataSyncServiceTest {
+
+    private DataSyncService dataSyncService;
+
+    private SpoonacularApiService mockSpoonacularApiService;
+    private RecipeRepository mockRecipeRepository;
+
+    @BeforeEach
+    void setUp() {
+        mockSpoonacularApiService = mock(SpoonacularApiService.class);
+        mockRecipeRepository = mock(RecipeRepository.class);
+
+        dataSyncService = new DataSyncService(mockSpoonacularApiService, mockRecipeRepository);
+    }
+
+    @Test
+    void syncRecipes_savesNewRecipes_andSkipsExistingOnes() {
+
+        var newRecipeResult = new SpoonacularRecipeResult();
+        newRecipeResult.setId(101);
+        newRecipeResult.setTitle("New Test Pasta");
+
+        var existingRecipeResult = new SpoonacularRecipeResult();
+        existingRecipeResult.setId(102);
+        existingRecipeResult.setTitle("Existing Test Soup");
+
+        var response = new SpoonacularSearchResponse();
+        response.setResults(List.of(newRecipeResult, existingRecipeResult));
+
+
+        when(mockSpoonacularApiService.searchRecipes("italian")).thenReturn(response);
+
+        when(mockRecipeRepository.existsBySpoonacularId(101)).thenReturn(false);
+
+        when(mockRecipeRepository.existsBySpoonacularId(102)).thenReturn(true);
+
+
+
+        dataSyncService.syncRecipes();
+
+
+
+        verify(mockSpoonacularApiService, times(1)).searchRecipes("italian");
+
+        verify(mockRecipeRepository, times(1)).existsBySpoonacularId(101);
+        verify(mockRecipeRepository, times(1)).existsBySpoonacularId(102);
+
+        verify(mockRecipeRepository, times(1)).save(any(Recipe.class));
+
+    }
+}

--- a/src/test/java/io/everyonecodes/pbl_module_milihe/service/RecipeServiceTest.java
+++ b/src/test/java/io/everyonecodes/pbl_module_milihe/service/RecipeServiceTest.java
@@ -16,27 +16,18 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  */
 class RecipeServiceTest {
 
-    // The class we are testing
     private RecipeService recipeService;
 
-    // The RecipeRepository is not used in the method we are testing,
-    // as it calls another method in the same class (findAllRecipes).
-    // We will control the data by overriding that method.
 
     /**
      * This method runs before each test to set up a clean environment.
      */
     @BeforeEach
     void setUp() {
-        // We instantiate our service. Because the method we want to test
-        // calls another public method in the same class (findAllRecipes),
-        // we will override findAllRecipes here to provide controlled test data.
-        // This is a simple way to test the logic of one method in isolation.
-        recipeService = new RecipeService(null) { // Passing null as we won't use the real repository.
+
+        recipeService = new RecipeService(null) {
             @Override
             public List<RecipeDTO> findAllRecipes() {
-                // This override ensures that when our test calls findAllRecipes(),
-                // it gets this specific, controlled list of fake data.
                 return createTestRecipeData();
             }
         };
@@ -49,37 +40,24 @@ class RecipeServiceTest {
      */
     @Test
     void findRecipesByIngredients_shouldCalculateAndSortCorrectly() {
-        // --- ARRANGE ---
-        // Define the ingredients the user has.
+
         List<String> userIngredients = List.of("Tomato", "Pasta", "Onion");
 
-        // The test data is provided by the overridden findAllRecipes() method.
-
-        // --- ACT ---
-        // Call the method we are testing.
         List<RecipeSuggestionDTO> actualSuggestions = recipeService.findRecipesByIngredients(userIngredients);
 
-        // --- ASSERT ---
-        // Verify that the results are calculated and sorted as expected.
-
-        // We expect 3 suggestions in total.
         assertEquals(3, actualSuggestions.size());
 
-        // The FIRST result should be "Pasta with Tomato" because it has 0 missing ingredients.
         RecipeSuggestionDTO perfectMatch = actualSuggestions.get(0);
         assertEquals("Pasta with Tomato", perfectMatch.getTitle());
         assertEquals(0, perfectMatch.getMissingIngredientCount());
         assertEquals(2, perfectMatch.getMatchedIngredientCount());
-        assertEquals(List.of(), perfectMatch.getMissingIngredients()); // Empty list of missing ingredients.
-
-        // The SECOND result should be "Onion Soup" because it has 1 missing ingredient.
+        assertEquals(List.of(), perfectMatch.getMissingIngredients());
         RecipeSuggestionDTO closeMatch = actualSuggestions.get(1);
         assertEquals("Onion Soup", closeMatch.getTitle());
         assertEquals(1, closeMatch.getMissingIngredientCount());
         assertEquals(1, closeMatch.getMatchedIngredientCount());
         assertEquals(List.of("Broth"), closeMatch.getMissingIngredients());
 
-        // The THIRD result should be "Chicken Stir-fry" because it has 2 missing ingredients.
         RecipeSuggestionDTO badMatch = actualSuggestions.get(2);
         assertEquals("Chicken Stir-fry", badMatch.getTitle());
         assertEquals(2, badMatch.getMissingIngredientCount());
@@ -94,7 +72,7 @@ class RecipeServiceTest {
      * @return A list of RecipeDTOs for testing.
      */
     private List<RecipeDTO> createTestRecipeData() {
-        // Recipe 1: Perfect match (requires 2 ingredients, user has both)
+
         RecipeDTO pastaRecipe = new RecipeDTO(
                 1L, 0, "Pasta with Tomato", 0, 0, false, false, false, false, 0, null, null, null, null,
                 List.of(
@@ -103,26 +81,23 @@ class RecipeServiceTest {
                 )
         );
 
-        // Recipe 2: Close match (requires 2 ingredients, user has 1, is missing 1)
         RecipeDTO onionSoup = new RecipeDTO(
                 2L, 0, "Onion Soup", 0, 0, false, true, false, false, 0, null, null, null, null,
                 List.of(
                         new RecipeIngredientDTO(0, "Onion", null, 0, null, null),
-                        new RecipeIngredientDTO(0, "Broth", null, 0, null, null) // This one is missing
+                        new RecipeIngredientDTO(0, "Broth", null, 0, null, null)
                 )
         );
 
-        // Recipe 3: Bad match (requires 3 ingredients, user has 1, is missing 2)
         RecipeDTO stirFry = new RecipeDTO(
                 3L, 0, "Chicken Stir-fry", 0, 0, false, false, false, false, 0, null, null, null, null,
                 List.of(
                         new RecipeIngredientDTO(0, "Onion", null, 0, null, null),
-                        new RecipeIngredientDTO(0, "Chicken", null, 0, null, null),   // Missing
-                        new RecipeIngredientDTO(0, "Soy Sauce", null, 0, null, null) // Missing
+                        new RecipeIngredientDTO(0, "Chicken", null, 0, null, null),
+                        new RecipeIngredientDTO(0, "Soy Sauce", null, 0, null, null)
                 )
         );
 
-        // Return the list in an unsorted order to properly test the sorting logic.
         return List.of(stirFry, pastaRecipe, onionSoup);
     }
 }


### PR DESCRIPTION
This commit introduces the core data synchronization pipeline, enabling the application to fetch recipes from the external Spoonacular API and save them to the local database.

- Creates `SpoonacularApiService` to handle HTTP communication with the Spoonacular API, using `RestTemplate` to fetch recipe data.

- Adds external DTOs (`SpoonacularSearchResponse`, `SpoonacularRecipeResult`) to deserialize the JSON response from the API.

- Implements `DataSyncService` to orchestrate the sync process, including the logic to map external DTOs to internal JPA entities.

- Adds "insert-or-skip" upsert logic to `DataSyncService` to prevent the creation of duplicate recipes on subsequent sync runs.

- Creates a `DataSyncController` with a manual `POST /api/sync/recipes` endpoint to trigger the synchronization process.

- Includes a comprehensive unit test (`DataSyncServiceTest`) using Mockito to verify the service's business logic, including duplicate prevention, in isolation.