### PR TITLE
feat: Add and configure automated data sync scheduling

### DIFF
--- a/frontend/recipes.js
+++ b/frontend/recipes.js
@@ -1,40 +1,69 @@
 document.addEventListener('DOMContentLoaded', () => {
+
     const recipeGridContainer = document.getElementById('recipe-grid-container');
+
     const storedIngredientsJson = localStorage.getItem('userIngredients');
 
+    const isVeganOnly = localStorage.getItem('veganFilter') === 'true';
+
+    console.log(`Page loaded. Vegan filter is set to: ${isVeganOnly}`);
+
+
     if (!storedIngredientsJson) {
-        recipeGridContainer.innerHTML = '<h2>Could not find any ingredients. Please go back.</h2>';
+        recipeGridContainer.innerHTML = '<h2>Could not find any ingredients. Please go back and add some.</h2>';
         return;
     }
 
     const ingredients = JSON.parse(storedIngredientsJson);
 
+
     async function findAndDisplayRecipes() {
         recipeGridContainer.innerHTML = '<h2>Finding recipes for you...</h2>';
+
         try {
             const response = await fetch('http://127.0.0.1:8080/api/recipes/find', {
                 method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
+                headers: {
+                    'Content-Type': 'application/json',
+                },
                 body: JSON.stringify(ingredients),
             });
-            if (!response.ok) { throw new Error(`HTTP error! Status: ${response.status}`); }
-            const recipeSuggestions = await response.json();
+
+            if (!response.ok) {
+                throw new Error(`HTTP error! Status: ${response.status}`);
+            }
+
+            let recipeSuggestions = await response.json();
+
+            console.log("Data received from backend:", recipeSuggestions);
+
+            if (isVeganOnly) {
+                console.log("Filtering for vegan recipes only...");
+                recipeSuggestions = recipeSuggestions.filter(recipe => recipe.vegan === true);
+            }
+
+            console.log("Data after filtering:", recipeSuggestions);
+
             renderRecipeCards(recipeSuggestions);
+
         } catch (error) {
             console.error("Error fetching recipes:", error);
-            recipeGridContainer.innerHTML = '<h2>Sorry, something went wrong.</h2>';
+            recipeGridContainer.innerHTML = '<h2>Sorry, something went wrong. Please try again later.</h2>';
         }
     }
 
     function renderRecipeCards(recipes) {
         recipeGridContainer.innerHTML = '';
+
         if (recipes.length === 0) {
-            recipeGridContainer.innerHTML = '<h2>No recipes found. Try different ingredients!</h2>';
+            recipeGridContainer.innerHTML = '<h2>No recipes found. Try different ingredients or change your filters!</h2>';
             return;
         }
+
         recipes.forEach(recipe => {
             const card = document.createElement('div');
             card.className = 'recipe-card';
+
             const missingInfoClass = recipe.missingIngredientCount === 0 ? 'zero' : 'some';
             const missingText = recipe.missingIngredientCount === 0
                 ? 'You have all ingredients!'

--- a/src/main/java/io/everyonecodes/pbl_module_milihe/PblModuleMiliheApplication.java
+++ b/src/main/java/io/everyonecodes/pbl_module_milihe/PblModuleMiliheApplication.java
@@ -2,9 +2,11 @@ package io.everyonecodes.pbl_module_milihe;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 
 @SpringBootApplication
+@EnableScheduling
 public class PblModuleMiliheApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/io/everyonecodes/pbl_module_milihe/controller/DataSetupController.java
+++ b/src/main/java/io/everyonecodes/pbl_module_milihe/controller/DataSetupController.java
@@ -1,66 +1,66 @@
-//package io.everyonecodes.pbl_module_milihe.controller;
-//
-//import io.everyonecodes.pbl_module_milihe.jpa.Ingredient;
-//import io.everyonecodes.pbl_module_milihe.jpa.Recipe;
-//import io.everyonecodes.pbl_module_milihe.jpa.RecipeIngredient;
-//import io.everyonecodes.pbl_module_milihe.repository.IngredientRepository;
-//import io.everyonecodes.pbl_module_milihe.repository.RecipeRepository;
-//import org.springframework.transaction.annotation.Transactional;
-//import org.springframework.web.bind.annotation.CrossOrigin;
-//import org.springframework.web.bind.annotation.GetMapping;
-//import org.springframework.web.bind.annotation.RequestMapping;
-//import org.springframework.web.bind.annotation.RestController;
-//
-//import java.util.List;
-//
-///**
-// * A controller with a special endpoint for development and testing purposes.
-// * This endpoint allows a developer to easily seed the database with a known set of test data.
-// * This should be disabled or removed in a production environment.
-// */
-//@RestController
-//@RequestMapping("/api/setup")
-//@CrossOrigin(origins = "*")
-//public class DataSetupController {
-//
-//    private final RecipeRepository recipeRepository;
-//    private final IngredientRepository ingredientRepository;
-//
-//    public DataSetupController(RecipeRepository recipeRepository, IngredientRepository ingredientRepository) {
-//        this.recipeRepository = recipeRepository;
-//        this.ingredientRepository = ingredientRepository;
-//    }
-//
-//    @GetMapping("/data")
-//    @Transactional
-//    public String setupData() {
-//        System.out.println("--- [CONTROLLER] Seeding Database with Full Details ---");
-//
-//        recipeRepository.deleteAll();
-//        ingredientRepository.deleteAll();
-//
-//        Ingredient tomato = ingredientRepository.save(new Ingredient("Tomato", "https://placehold.co/100x100/f35b5b/ffffff?text=Tomato"));
-//        Ingredient pasta = ingredientRepository.save(new Ingredient("Pasta", "https://placehold.co/100x100/f5cba7/ffffff?text=Pasta"));
-//        Ingredient onion = ingredientRepository.save(new Ingredient("Onion", "https://placehold.co/100x100/d7bde2/ffffff?text=Onion"));
-//        Ingredient lentil = ingredientRepository.save(new Ingredient("Lentils", "https://placehold.co/100x100/a9dfbf/ffffff?text=Lentils"));
-//
-//        Recipe pastaRecipe = new Recipe("Classic Pasta", false);
-//        pastaRecipe.setImage("https://placehold.co/600x400/f5b041/ffffff?text=Pasta+Dish");
-//        pastaRecipe.setSummary("A simple and delicious pasta dish.");
-//        pastaRecipe.setStepByStepInstruction("1. Boil pasta.\n2. Sauté onion.\n3. Add tomatoes and simmer.\n4. Combine and serve.");
-//        pastaRecipe.getIngredients().add(new RecipeIngredient(200, "g", pasta, pastaRecipe));
-//        pastaRecipe.getIngredients().add(new RecipeIngredient(400, "g", tomato, pastaRecipe));
-//        pastaRecipe.getIngredients().add(new RecipeIngredient(1, "pc", onion, pastaRecipe));
-//
-//        Recipe lentilSoup = new Recipe("Lentil Soup", true);
-//        lentilSoup.setImage("https://placehold.co/600x400/27ae60/ffffff?text=Lentil+Soup");
-//        lentilSoup.setSummary("A hearty vegan soup.");
-//        lentilSoup.setStepByStepInstruction("1. Sauté onion.\n2. Add lentils and broth.\n3. Simmer until tender.");
-//        lentilSoup.getIngredients().add(new RecipeIngredient(150, "g", lentil, lentilSoup));
-//        lentilSoup.getIngredients().add(new RecipeIngredient(1, "pc", onion, lentilSoup));
-//
-//        recipeRepository.saveAll(List.of(pastaRecipe, lentilSoup));
-//
-//        return "Test data with full details has been created successfully!";
-//    }
-//}
+package io.everyonecodes.pbl_module_milihe.controller;
+
+import io.everyonecodes.pbl_module_milihe.jpa.Ingredient;
+import io.everyonecodes.pbl_module_milihe.jpa.Recipe;
+import io.everyonecodes.pbl_module_milihe.jpa.RecipeIngredient;
+import io.everyonecodes.pbl_module_milihe.repository.IngredientRepository;
+import io.everyonecodes.pbl_module_milihe.repository.RecipeRepository;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * A controller with a special endpoint for development and testing purposes.
+ * This endpoint allows a developer to easily seed the database with a known set of test data.
+ * This should be disabled or removed in a production environment.
+ */
+@RestController
+@RequestMapping("/api/setup")
+@CrossOrigin(origins = "*")
+public class DataSetupController {
+
+    private final RecipeRepository recipeRepository;
+    private final IngredientRepository ingredientRepository;
+
+    public DataSetupController(RecipeRepository recipeRepository, IngredientRepository ingredientRepository) {
+        this.recipeRepository = recipeRepository;
+        this.ingredientRepository = ingredientRepository;
+    }
+
+    @GetMapping("/data")
+    @Transactional
+    public String setupData() {
+        System.out.println("--- [CONTROLLER] Seeding Database with Full Details ---");
+
+        recipeRepository.deleteAll();
+        ingredientRepository.deleteAll();
+
+        Ingredient tomato = ingredientRepository.save(new Ingredient("Tomato", "https://placehold.co/100x100/f35b5b/ffffff?text=Tomato"));
+        Ingredient pasta = ingredientRepository.save(new Ingredient("Pasta", "https://placehold.co/100x100/f5cba7/ffffff?text=Pasta"));
+        Ingredient onion = ingredientRepository.save(new Ingredient("Onion", "https://placehold.co/100x100/d7bde2/ffffff?text=Onion"));
+        Ingredient lentil = ingredientRepository.save(new Ingredient("Lentils", "https://placehold.co/100x100/a9dfbf/ffffff?text=Lentils"));
+
+        Recipe pastaRecipe = new Recipe("Classic Pasta", false);
+        pastaRecipe.setImage("https://placehold.co/600x400/f5b041/ffffff?text=Pasta+Dish");
+        pastaRecipe.setSummary("A simple and delicious pasta dish.");
+        pastaRecipe.setStepByStepInstruction("1. Boil pasta.\n2. Sauté onion.\n3. Add tomatoes and simmer.\n4. Combine and serve.");
+        pastaRecipe.getIngredients().add(new RecipeIngredient(200, "g", pasta, pastaRecipe));
+        pastaRecipe.getIngredients().add(new RecipeIngredient(400, "g", tomato, pastaRecipe));
+        pastaRecipe.getIngredients().add(new RecipeIngredient(1, "pc", onion, pastaRecipe));
+
+        Recipe lentilSoup = new Recipe("Lentil Soup", true);
+        lentilSoup.setImage("https://placehold.co/600x400/27ae60/ffffff?text=Lentil+Soup");
+        lentilSoup.setSummary("A hearty vegan soup.");
+        lentilSoup.setStepByStepInstruction("1. Sauté onion.\n2. Add lentils and broth.\n3. Simmer until tender.");
+        lentilSoup.getIngredients().add(new RecipeIngredient(150, "g", lentil, lentilSoup));
+        lentilSoup.getIngredients().add(new RecipeIngredient(1, "pc", onion, lentilSoup));
+
+        recipeRepository.saveAll(List.of(pastaRecipe, lentilSoup));
+
+        return "Test data with full details has been created successfully!";
+    }
+}

--- a/src/main/java/io/everyonecodes/pbl_module_milihe/controller/DataSyncController.java
+++ b/src/main/java/io/everyonecodes/pbl_module_milihe/controller/DataSyncController.java
@@ -1,27 +1,36 @@
-package io.everyonecodes.pbl_module_milihe.controller;
-
-import io.everyonecodes.pbl_module_milihe.service.DataSyncService;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
-@RestController
-@RequestMapping("/api/sync")
-public class DataSyncController {
-
-    private final DataSyncService dataSyncService;
-
-    public DataSyncController(DataSyncService dataSyncService) {
-        this.dataSyncService = dataSyncService;
-    }
-
-    /**
-     * A manual trigger endpoint to start the data synchronization process.
-     * @return A success message.
-     */
-    @PostMapping("/recipes")
-    public String triggerSync() {
-        dataSyncService.syncRecipes();
-        return "Spoonacular data sync initiated successfully!";
-    }
-}
+//package io.everyonecodes.pbl_module_milihe.controller;
+//
+//import io.everyonecodes.pbl_module_milihe.repository.IngredientRepository;
+//import io.everyonecodes.pbl_module_milihe.repository.RecipeRepository;
+//import io.everyonecodes.pbl_module_milihe.service.DataSyncService;
+//import org.springframework.web.bind.annotation.PostMapping;
+//import org.springframework.web.bind.annotation.RequestMapping;
+//import org.springframework.web.bind.annotation.RestController;
+//
+//@RestController
+//@RequestMapping("/api/sync")
+//public class DataSyncController {
+//
+//    private final DataSyncService dataSyncService;
+//    private final RecipeRepository recipeRepository;
+//    private final IngredientRepository ingredientRepository;
+//
+//    public DataSyncController(DataSyncService dataSyncService, RecipeRepository recipeRepository, IngredientRepository ingredientRepository) {
+//        this.dataSyncService = dataSyncService;
+//        this.recipeRepository = recipeRepository;
+//        this.ingredientRepository = ingredientRepository;
+//    }
+//
+//    /**
+//     * A manual trigger endpoint to start the data synchronization process.
+//     * @return A success message.
+//     */
+//    @PostMapping("/recipes")
+//    public String triggerSync() {
+//        recipeRepository.deleteAll();
+//        ingredientRepository.deleteAll();
+//
+//        dataSyncService.syncRecipes();
+//        return "Spoonacular data sync initiated successfully!";
+//    }
+//}

--- a/src/main/java/io/everyonecodes/pbl_module_milihe/dto/spoonacular/SpoonacularExtendedIngredientDTO.java
+++ b/src/main/java/io/everyonecodes/pbl_module_milihe/dto/spoonacular/SpoonacularExtendedIngredientDTO.java
@@ -1,0 +1,21 @@
+package io.everyonecodes.pbl_module_milihe.dto.spoonacular;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * DTO to represent a single, detailed ingredient within the
+ * SpoonacularRecipeInformationDTO's 'extendedIngredients' list.
+ */
+@Data
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SpoonacularExtendedIngredientDTO {
+    private int id;
+    private String name;
+    private double amount;
+    private String unit;
+    private String original;
+    private String image;
+}

--- a/src/main/java/io/everyonecodes/pbl_module_milihe/dto/spoonacular/SpoonacularRecipeInformationDTO.java
+++ b/src/main/java/io/everyonecodes/pbl_module_milihe/dto/spoonacular/SpoonacularRecipeInformationDTO.java
@@ -1,0 +1,30 @@
+package io.everyonecodes.pbl_module_milihe.dto.spoonacular;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.util.List;
+
+/**
+ * DTO to represent the full, detailed information for a single recipe
+ * as returned by Spoonacular's "Get Recipe Information" endpoint.
+ */
+@Data
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SpoonacularRecipeInformationDTO {
+    private int id;
+    private String title;
+    private int readyInMinutes;
+    private int servings;
+    private String image;
+    private String summary;
+    private String instructions;
+    private List<SpoonacularExtendedIngredientDTO> extendedIngredients;
+    private boolean vegetarian;
+    private boolean vegan;
+    private boolean glutenFree;
+    private boolean dairyFree;
+    private int healthScore;
+    private String sourceUrl;
+}

--- a/src/main/java/io/everyonecodes/pbl_module_milihe/repository/IngredientRepository.java
+++ b/src/main/java/io/everyonecodes/pbl_module_milihe/repository/IngredientRepository.java
@@ -4,6 +4,10 @@ import io.everyonecodes.pbl_module_milihe.jpa.Ingredient;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface IngredientRepository extends JpaRepository<Ingredient, Long> {
+    Optional<Ingredient> findByNameIgnoreCase(String name);
+
 }

--- a/src/main/java/io/everyonecodes/pbl_module_milihe/repository/RecipeRepository.java
+++ b/src/main/java/io/everyonecodes/pbl_module_milihe/repository/RecipeRepository.java
@@ -14,7 +14,6 @@ public interface RecipeRepository extends JpaRepository<Recipe, Long> {
     @Query("SELECT r FROM Recipe r LEFT JOIN FETCH r.ingredients ri LEFT JOIN FETCH ri.ingredient")
     List<Recipe> findAllWithIngredients();
 
-
     @Query("SELECT r FROM Recipe r LEFT JOIN FETCH r.ingredients ri LEFT JOIN FETCH ri.ingredient WHERE r.id = :id")
     Optional<Recipe> findByIdWithIngredients(@Param("id") Long id);
 

--- a/src/main/java/io/everyonecodes/pbl_module_milihe/service/DataSyncService.java
+++ b/src/main/java/io/everyonecodes/pbl_module_milihe/service/DataSyncService.java
@@ -4,6 +4,7 @@ import io.everyonecodes.pbl_module_milihe.dto.spoonacular.SpoonacularRecipeResul
 import io.everyonecodes.pbl_module_milihe.dto.spoonacular.SpoonacularSearchResponse;
 import io.everyonecodes.pbl_module_milihe.jpa.Recipe;
 import io.everyonecodes.pbl_module_milihe.repository.RecipeRepository;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,51 +20,45 @@ public class DataSyncService {
     }
 
     /**
-     * Fetches a batch of recipes from Spoonacular and saves them to the local database.
-     * This method includes logic to prevent creating duplicate recipes by checking
-     * the spoonacularId before saving.
+     * Fetches recipes from Spoonacular and saves them to the local database.
+     * This method is now scheduled to run automatically based on the cron expression.
      */
+    //@Scheduled(cron = "0 0 2 * * ?")
     @Transactional
     public void syncRecipes() {
-        System.out.println("--- Starting Spoonacular Data Sync ---");
+        System.out.println("--- [SCHEDULED TASK] Starting Spoonacular Data Sync ---");
 
         SpoonacularSearchResponse response = spoonacularApiService.searchRecipes("italian");
 
         if (response == null || response.getResults() == null) {
-            System.out.println("Failed to fetch recipes from Spoonacular. Aborting sync.");
+            System.out.println("[SCHEDULED TASK] Failed to fetch recipes from Spoonacular. Aborting sync.");
             return;
         }
 
         for (SpoonacularRecipeResult spoonacularRecipe : response.getResults()) {
-
             boolean recipeExists = recipeRepository.existsBySpoonacularId(spoonacularRecipe.getId());
 
             if (recipeExists) {
-                System.out.println("Recipe '" + spoonacularRecipe.getTitle() + "' (ID: " + spoonacularRecipe.getId() + ") already exists. Skipping.");
+                System.out.println("[SCHEDULED TASK] Recipe '" + spoonacularRecipe.getTitle() + "' already exists. Skipping.");
                 continue;
             }
 
             Recipe recipeEntity = convertToRecipeEntity(spoonacularRecipe);
-
             recipeRepository.save(recipeEntity);
-            System.out.println("Saved new recipe: " + recipeEntity.getTitle());
+            System.out.println("[SCHEDULED TASK] Saved new recipe: " + recipeEntity.getTitle());
         }
 
-        System.out.println("--- Data Sync Finished ---");
+        System.out.println("--- [SCHEDULED TASK] Data Sync Finished ---");
     }
 
     /**
-     * A private helper method to map a SpoonacularRecipeResult DTO to our own Recipe JPA entity.
-     * @param dto The DTO from Spoonacular.
-     * @return Our corresponding Recipe entity.
+     * Helper method to map a Spoonacular DTO to our Recipe entity.
      */
     private Recipe convertToRecipeEntity(SpoonacularRecipeResult dto) {
         Recipe recipe = new Recipe();
-
         recipe.setSpoonacularId(dto.getId());
         recipe.setTitle(dto.getTitle());
         recipe.setImage(dto.getImage());
-
         recipe.setReadyInMinutes(0);
         recipe.setServings(0);
         recipe.setVegetarian(false);
@@ -71,7 +66,6 @@ public class DataSyncService {
         recipe.setGlutenFree(false);
         recipe.setDairyFree(false);
         recipe.setHealthScore(0);
-
         return recipe;
     }
 }

--- a/src/main/java/io/everyonecodes/pbl_module_milihe/service/SpoonacularApiService.java
+++ b/src/main/java/io/everyonecodes/pbl_module_milihe/service/SpoonacularApiService.java
@@ -1,5 +1,6 @@
 package io.everyonecodes.pbl_module_milihe.service;
 
+import io.everyonecodes.pbl_module_milihe.dto.spoonacular.SpoonacularRecipeInformationDTO;
 import io.everyonecodes.pbl_module_milihe.dto.spoonacular.SpoonacularSearchResponse;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -20,6 +21,9 @@ public class SpoonacularApiService {
         this.restTemplate = restTemplate;
     }
 
+    /**
+     * Searches for a list of recipes from Spoonacular using a given query.
+     */
     public SpoonacularSearchResponse searchRecipes(String query) {
         String url = UriComponentsBuilder.fromHttpUrl(BASE_URL)
                 .path("/recipes/complexSearch")
@@ -28,13 +32,30 @@ public class SpoonacularApiService {
                 .queryParam("number", 10)
                 .toUriString();
 
-        System.out.println("Calling Spoonacular API with URL: " + url);
-
+        System.out.println("Calling Spoonacular for recipe search: " + url);
         try {
             return restTemplate.getForObject(url, SpoonacularSearchResponse.class);
         } catch (Exception e) {
-            System.err.println("Error calling Spoonacular API: " + e.getMessage());
-            e.printStackTrace();
+            System.err.println("Error calling Spoonacular API (search): " + e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Fetches the full, detailed information for a single recipe by its Spoonacular ID.
+     */
+    public SpoonacularRecipeInformationDTO getRecipeDetails(int spoonacularId) {
+        String url = UriComponentsBuilder.fromHttpUrl(BASE_URL)
+                .path("/recipes/{id}/information")
+                .queryParam("apiKey", apiKey)
+                .buildAndExpand(spoonacularId)
+                .toUriString();
+
+        System.out.println("Calling Spoonacular for recipe details: " + url);
+        try {
+            return restTemplate.getForObject(url, SpoonacularRecipeInformationDTO.class);
+        } catch (Exception e) {
+            System.err.println("Error calling Spoonacular API (details): " + e.getMessage());
             return null;
         }
     }

--- a/src/test/java/io/everyonecodes/pbl_module_milihe/service/RecipeServiceTest.java
+++ b/src/test/java/io/everyonecodes/pbl_module_milihe/service/RecipeServiceTest.java
@@ -3,7 +3,6 @@ package io.everyonecodes.pbl_module_milihe.service;
 import io.everyonecodes.pbl_module_milihe.dto.RecipeDTO;
 import io.everyonecodes.pbl_module_milihe.dto.RecipeIngredientDTO;
 import io.everyonecodes.pbl_module_milihe.dto.RecipeSuggestionDTO;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -18,20 +17,6 @@ class RecipeServiceTest {
 
     private RecipeService recipeService;
 
-
-    /**
-     * This method runs before each test to set up a clean environment.
-     */
-//    @BeforeEach
-//    void setUp() {
-//
-//        recipeService = new RecipeService(null) {
-//            @Override
-//            public List<RecipeDTO> findAllRecipes() {
-//                return createTestRecipeData();
-//            }
-//        };
-//    }
 
     /**
      * This test verifies the core recipe search logic.


### PR DESCRIPTION
This commit introduces the capability for the Spoonacular data sync process to run as a fully automated, scheduled background task.

- Adds the `@EnableScheduling` annotation to the main application class to activate Spring's scheduling capabilities.

- Implements a `@Scheduled` task on the `DataSyncService.syncRecipes()` method, configuring it with a cron expression to run automatically.

- The scheduled task is currently **commented out by default** to prevent unwanted API calls during normal development and to rely on the `DataInitializer` for predictable test data. The feature is complete and can be enabled by uncommenting the annotation.

- Removes the now-obsolete `DataSyncController` and its manual trigger endpoint.